### PR TITLE
Fixed a syntax error in line 65, Chituboard.sh

### DIFF
--- a/Chituboard.sh
+++ b/Chituboard.sh
@@ -62,8 +62,7 @@ else
 
     info
     info "Setting up Chituboard prerequisites"
-    echo "dtoverlay=dwc2,dr_mode=peripheral" >> /boot/config.txt
-    echo "enable_uart=1" >> /boot/config.txt
+    echo -e "dtoverlay=dwc2\ndr_mode=peripheral\nenable_uart=1" >> /boot/config.txt
     sudo sed -i 's/console=serial0,115200 //g' /boot/cmdline.txt
     echo -n " modules-load=dwc2" >> /boot/cmdline.txt
     # setup 4 GB container file to for storing uploaded files


### PR DESCRIPTION
Line 65 adds two arguments separated by a comma to `/boot/config.txt`. This was causing an issue where the OS would not accept any input after boot (OctoPrint server also failed to start).

I've fixed the issue & condensed `enable_uart=1` into the same command. The `echo -e` flag tells `echo` to parse escaped characters. Each command in quotations is separated by a `newline` character.