### PR TITLE
refactor shell script

### DIFF
--- a/Chituboard.sh
+++ b/Chituboard.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Exit on error
+set -euo pipefail
+
 # filename: Chituboard.sh
 # modified version of Kenzillla's Mariner+Samba Auto-Installer
 
@@ -12,116 +15,94 @@ if ! [ "$(id -u)" = 0 ]; then
     exit 1
 fi
 
-# check if the reboot flag file exists. 
-# We created this file before rebooting.
-if [ ! -f ./resume-Chituboard ]; then
-    warn "running script for the first time.."
+info
+info "Welcome to Octoprint+Samba Auto-Installer!"
+sleep .1
+info "..."
+
+sleep 1
+
+# Checks the base of the dir this script is being run in such as /home/username/Chituboard.sh 
+# This sets the var to the last directory in the file path.
+ASSUMED_USER=$(basename "$(pwd)") 
+DEFAULT_USER="pi"
+
+info "File is being run in $(pwd)"
+info "Which user account should the be installed in that contains your octoprint config?  The user may be ${ASSUMED_USER}."
+info "Please confirm this below or choose another user."
+
+read -r user_input
+
+USER="${user_input:-${DEFAULT_USER}}"
+
+info "User is: ${USER}"
+
+info
+info "Setting up Chituboard prerequisites"
+echo "dtoverlay=dwc2,dr_mode=peripheral" >> /boot/config.txt
+echo "enable_uart=1" >> /boot/config.txt
+sudo sed -i 's/console=serial0,115200 //g' /boot/cmdline.txt
+echo -n " modules-load=dwc2" >> /boot/cmdline.txt
+
+# Setup 4 GB container file to for storing uploaded files
+info
+info "Setting up Pi-USB (4GB); this could take several minutes"
+sudo dd bs=1M if=/dev/zero of=/piusb.bin count=4096
+sudo mkdosfs /piusb.bin -F 32 -I
+# Create the mount point for the container file
+sudo mkdir /home/"${USER}"/.octoprint/uploads/resin
+echo "/piusb.bin            /home/${USER}/.octoprint/uploads/resin  vfat    users,uid=${USER},gid=${USER},umask=000   0       2 " >> /etc/fstab
+
+sudo mount -a
+
+sudo sed -i 's/exit 0//g' /etc/rc.local
+
+echo '/bin/sleep 5
+modprobe g_mass_storage file=/piusb.bin removable=1 ro=0 stall=0
+exit 0' >> /etc/rc.local
+
+sudo systemctl stop serial-getty@ttyS0
+sudo systemctl disable serial-getty@ttyS0
+
+info ""
+info "Setting up Sambashare; this could take a long time"
+sudo apt-get install samba winbind -y
+
+read -r -p "Enter a short description of your printer, like the model: "  model
+echo "[USB_Share]
+comment = $model
+path = /home/${USER}/.octoprint/uploads/resin/
+browseable = Yes
+writeable = Yes
+only guest = no
+create mask = 0777
+directory mask = 0777
+public = yes
+read only = no
+force user = root
+force group = root" >> /etc/samba/smb.conf
+
+info ""
+
+while true
+do
+    warn "Confirm your disk setup looks correct before rebooting"
+    df -h
     
-    # run your scripts here
-    info
-    info "Welcome to Octoprint+Samba Auto-Installer!"
-    sleep .1
-    info "..."
+    read -r -p "Reboot now? [Y/n] " input
 
-    sleep 1
-# remove this part, octoprint install is already expanded filesystem
-
-    warn "It is a good idea to change your password from the default"
-    while true
-    do
-        read -r -p "Change now? [Y/n] " input
-    
-        case $input in
-            [yY][eE][sS]|[yY])
-        info
-        echo "$(passwd pi)"
-        break
-        ;;
-            [nN][oO]|[nN])
-        break
-                ;;
-            *)
-        warn "Invalid input..."
-        esac
-    done
-
-    # create a flag file to check if we are resuming from reboot.
-    sudo touch ./resume-Chituboard
-
-    info "rebooting.."
-    # reboot here
-    sudo reboot
+    case $input in
+        [yY][eE][sS]|[yY])
+    warn "Rebooting in 5 seconds"
     sleep 5
+    sudo reboot
+    break
+    ;;
+        [nN][oO]|[nN])
+    break
+            ;;
+        *)
+    warn "Invalid input..."
+    esac
+done
 
-else 
-    warn "resuming script after reboot.."
-    
-    # remove the temporary file that we created to check for reboot
-    sudo rm -f ./resume-Chituboard
-    # continue with rest of the script
-
-    info
-    info "Setting up Chituboard prerequisites"
-    echo "dtoverlay=dwc2,dr_mode=peripheral" >> /boot/config.txt
-    echo "enable_uart=1" >> /boot/config.txt
-    sudo sed -i 's/console=serial0,115200 //g' /boot/cmdline.txt
-    echo -n " modules-load=dwc2" >> /boot/cmdline.txt
-    # setup 4 GB container file to for storing uploaded files
-    info
-    info "Setting up Pi-USB; this could take several minutes"
-    sudo dd bs=1M if=/dev/zero of=/piusb.bin count=4096
-    sudo mkdosfs /piusb.bin -F 32 -I
-    # Create the mount point for the container file
-    sudo mkdir /home/pi/.octoprint/uploads/resin
-    echo "/piusb.bin            /home/pi/.octoprint/uploads/resin  vfat    users,uid=pi,gid=pi,umask=000   0       2 " >> /etc/fstab
-
-    sudo mount -a
-
-    sudo sed -i 's/exit 0//g' /etc/rc.local
-
-    echo '/bin/sleep 5
-    modprobe g_mass_storage file=/piusb.bin removable=1 ro=0 stall=0
-    exit 0' >> /etc/rc.local
-
-    sudo systemctl stop serial-getty@ttyS0
-    sudo systemctl disable serial-getty@ttyS0
-
-    info ""
-    info "Setting up Sambashare; this could take a long time"
-    sudo apt-get -y install samba winbind -y
-
-    read -r -p "Enter a short description of your printer, like the model: "  model
-    echo "[USB_Share]
-    comment = $model
-    path = /home/pi/.octoprint/uploads/resin/
-    browseable = Yes
-    writeable = Yes
-    only guest = no
-    create mask = 0777
-    directory mask = 0777
-    public = yes
-    read only = no
-    force user = root
-    force group = root" >> /etc/samba/smb.conf
-
-    info ""
-
-    while true
-    do
-        read -r -p "Reboot now? [Y/n] " input
-    
-        case $input in
-            [yY][eE][sS]|[yY])
-        warn "Rebooting in 5 seconds"
-        sleep 5
-        echo "$(sudo reboot)"
-        break
-        ;;
-            [nN][oO]|[nN])
-        break
-                ;;
-            *)
-        warn "Invalid input..."
-        esac
-    done
-fi


### PR DESCRIPTION
- Refactored the script to no longer ask to reset your password or require the resume file.  
  - This seemed unnecessary unless it was the first thing run in the official octoprint image.
  - Removed the resume file as a reboot was unnecessary at that point 
- Raspian/Raspberry OS no longer defaults to `pi` as the user so this script would attempt to create a disk in a non-existent path which then would not exit upon failure.  This caused my pi to fail to boot as the path in `/etc/fstab` didn't exist on reboot
- Added a prompt to specify the user to create the usb disk image in correctly.  
  - Defaulting to the user `pi` in the event the user does not specify any user to maintain existing functionality.
- More verbose messaging in how large of a disk is being created
  - TODO: Make this an option to customize.
- Removed extra `-y` in the samba install
- Added disk output to show the user if the usb disk mounted correctly if it hasn't errored out earlier